### PR TITLE
Snippets Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 lib
 node_modules
 .vsix
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,5 @@
 ## [0.0.3] - 2020-09-12
 - Added formatter - by Drew Powers <drew@pow.rs>
 
+## [0.0.4] - 2020-10-04
+- Added snippets - by Karam Fahad

--- a/README.md
+++ b/README.md
@@ -24,7 +24,29 @@ By default, only `.tera` files will be formatted. To add `.html` files (used for
   },
 ```
 
+## Snippets
+
+| Snippet | Description                        |
+| ------- | ---------------------------------- |
+| xx      | `{{ }}`                            |
+| block   | `{% block %} {% endblock %}`       |
+| inblock | Same as above but on a single line |
+| if      | `{% if %} {% endif %}`             |
+| ifi     | Same as above but on a single line |
+| ifelse  | `{% if %} {% elif %} {% endif %}`  |
+| else    | `{% else %}`                       |
+| filter  | `{% filter %} {% endfilter %}`     |
+| forloop | `{% for in %} {% endfor %}`        |
+| extend  | `{% extends "" %}`                 |
+| include | `{% include "" %}`                 |
+| import  | `{% import "" %}`                  |
+| macro   | `{% macro %} {% endmacro %}`       |
+
 ## Release Notes
+
+### 0.0.4
+
+Added snippets support.
 
 ### 0.0.3
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tera",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,78 +1,84 @@
 {
-  "name": "tera",
-  "displayName": "Tera",
-  "description": "A powerful, easy-to-use template language based on Rust, inspired by Jinja2 and Django Templates.",
-  "version": "0.0.2",
-  "publisher": "karunamurti",
-  "engines": {
-    "vscode": "^1.19.0"
-  },
-  "categories": [
-    "Programming Languages",
-    "Formatters"
-  ],
-  "license": "MIT",
-  "keywords": [
-    "tera",
-    "rust",
-    "zola"
-  ],
-  "main": "./lib/index.js",
-  "contributes": {
-    "configurationDefaults": {
-      "[tera]": {
-        "editor.defaultFormatter": "karunamurti.tera"
-      }
-    },
-    "languages": [
-      {
-        "id": "tera",
-        "aliases": [
-          "Tera Template",
-          "tera"
-        ],
-        "extensions": [
-          ".tera"
-        ],
-        "configuration": "./language-configuration.json"
-      }
-    ],
-    "grammars": [
-      {
-        "language": "tera",
-        "scopeName": "source.tera",
-        "path": "./syntaxes/tera.json"
-      }
-    ]
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/karuna/tera-vscode.git"
-  },
-  "galleryBanner": {
-    "color": "#888888",
-    "theme": "dark"
-  },
-  "homepage": "https://github.com/karuna/tera-vscode",
-  "bugs": {
-    "url": "https://github.com/karuna/tera-vscode/issues",
-    "email": "karuna.murti@gmail.com"
-  },
-  "icon": "images/logo.png",
-  "activationEvents": [
-    "onLanguage:tera"
-  ],
-  "scripts": {
-    "vscode:prepublish": "npm run build",
-    "build": "tsc",
-    "test": "npm run build && jest"
-  },
-  "dependencies": {
-    "prettydiff": "^101.2.6"
-  },
-  "devDependencies": {
-    "jest": "^26.4.2",
-    "typescript": "^4.0.2",
-    "vscode": "^1.1.37"
-  }
+	"name": "tera",
+	"displayName": "Tera",
+	"description": "A powerful, easy-to-use template language based on Rust, inspired by Jinja2 and Django Templates.",
+	"version": "0.0.4",
+	"publisher": "karunamurti",
+	"engines": {
+		"vscode": "^1.19.0"
+	},
+	"categories": [
+		"Programming Languages",
+		"Formatters"
+	],
+	"license": "MIT",
+	"keywords": [
+		"tera",
+		"rust",
+		"zola"
+	],
+	"main": "./lib/index.js",
+	"contributes": {
+		"configurationDefaults": {
+			"[tera]": {
+				"editor.defaultFormatter": "karunamurti.tera"
+			}
+		},
+		"languages": [
+			{
+				"id": "tera",
+				"aliases": [
+					"Tera Template",
+					"tera"
+				],
+				"extensions": [
+					".tera"
+				],
+				"configuration": "./language-configuration.json"
+			}
+		],
+		"grammars": [
+			{
+				"language": "tera",
+				"scopeName": "source.tera",
+				"path": "./syntaxes/tera.json"
+			}
+		],
+		"snippets": [
+			{
+				"language": "tera",
+				"path": "./snippets/tera.code-snippets.json"
+			}
+		]
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/karuna/tera-vscode.git"
+	},
+	"galleryBanner": {
+		"color": "#888888",
+		"theme": "dark"
+	},
+	"homepage": "https://github.com/karuna/tera-vscode",
+	"bugs": {
+		"url": "https://github.com/karuna/tera-vscode/issues",
+		"email": "karuna.murti@gmail.com"
+	},
+	"icon": "images/logo.png",
+	"activationEvents": [
+		"onLanguage:tera"
+	],
+	"scripts": {
+		"vscode:prepublish": "npm run build",
+		"build": "tsc",
+		"test": "npm run build && jest"
+	},
+	"dependencies": {
+		"prettydiff": "^101.2.6"
+	},
+	"devDependencies": {
+		"jest": "^26.4.2",
+		"typescript": "^4.0.2",
+		"vscode": "^1.1.37"
+	}
 }

--- a/snippets/tera.code-snippets.json
+++ b/snippets/tera.code-snippets.json
@@ -1,0 +1,95 @@
+{
+  "Variable": {
+    "prefix": "xx",
+    "body": "{{ $1 }}",
+    "description": "Renders a variable"
+  },
+  "Inline Block": {
+    "prefix": "inblock",
+    "body": "{% block $1 %} $2 {% endblock $3 %}",
+    "description": "A block of content inline on a single line"
+  },
+  "Block": {
+    "prefix": "block",
+    "body": [
+      "{% block $1 %}",
+      " $2",
+      "{% endblock $3 %}"
+    ],
+    "description": "A block of content"
+  },
+  "If": {
+    "prefix": "if",
+    "body": [
+      "{% if $1 %}",
+      " $2",
+      "{% endif %}"
+    ],
+    "description": "If conditional statement"
+  },
+  "Inline If": {
+    "prefix": "ifi",
+    "body": "{% if $1 %} $2 {% endif %}",
+    "description": "If conditional statement on a single line"
+  },
+  "If Else": {
+    "prefix": "ifelse",
+    "body": [
+      "{% if $1 %}",
+      " $2",
+      "{% elif $3 %}",
+      " $4",
+      "{% endif %}"
+    ],
+    "description": "else if conditional statement"
+  },
+  "Else": {
+    "prefix": "else",
+    "body": [
+      "{% else %}",
+      " $1"
+    ],
+    "description": "Else conditional statement"
+  },
+  "Filter": {
+    "prefix": "filter",
+    "body": [
+      "{% filter $1 %}",
+      " $2",
+      "{% endfilter %}"
+    ]
+  },
+  "For Loop": {
+    "prefix": "forloop",
+    "body": [
+      "{% for $1 in $2 %}",
+      " $3",
+      "{% endfor %}"
+    ],
+    "description": "Loop over items in an array"
+  },
+  "Extend": {
+    "prefix": "extend",
+    "body": "{% extends \"$1\" %}",
+    "description": "Inherits a template and all of its content"
+  },
+  "Include": {
+    "prefix": "include",
+    "body": "{% include \"$1\" %}",
+    "description": "Render a template using its current context"
+  },
+  "Import": {
+    "prefix": "import",
+    "body": "{% import \"$1\" as $2 %}",
+    "description": "Import a file containing a micro"
+  },
+  "Macro": {
+    "prefix": "macro",
+    "body": [
+      "{% macro $1 %}",
+      " $2",
+      "{% endmacro $3 %}"
+    ],
+    "description": "A function or a component that returns some text"
+  }
+}


### PR DESCRIPTION
This pull request addresses issue #2. Below is a summary of the changes that I made:

# .gitignore

Added .DS_Store extension to the ignore list. It's specific to Mac OS and does not really do anything.

# Changelog and Readme

- Mentioned that version 0.0.4 includes support for snippets
- Added a snippet section to the Readme file with all the snippets and their output

# Package.json

- Updated to version 0.0.4 and added snippets section as well that is specific to Tera

# snippets folder

Includes the most used snippets based on the Tera template documentation.

