### PR TITLE
change block snippet to only write block name once

### DIFF
--- a/snippets/tera.code-snippets.json
+++ b/snippets/tera.code-snippets.json
@@ -6,7 +6,7 @@
   },
   "Inline Block": {
     "prefix": "inblock",
-    "body": "{% block $1 %} $2 {% endblock $3 %}",
+    "body": "{% block $1 %} $2 {% endblock $1 %}",
     "description": "A block of content inline on a single line"
   },
   "Block": {
@@ -14,7 +14,7 @@
     "body": [
       "{% block $1 %}",
       " $2",
-      "{% endblock $3 %}"
+      "{% endblock $1 %}"
     ],
     "description": "A block of content"
   },


### PR DESCRIPTION
Since blocks should be closed with the same name as the opening name, writing block name only once suffice.