### PR TITLE
register the extension for `.tera` files

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         ],
         "extensions": [
           ".html",
-          ".htm"
+          ".htm",
+          ".tera"
         ],
         "configuration": "./language-configuration.json"
       }


### PR DESCRIPTION
When using tera templates in the Rocket the template files are called `name.html.tera`.