### PR TITLE
Support For Snippets in Markdown Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.0.8] - 20201-07-23
+
+- Snippets support in Markdown files
+- Syntax highlighting of tera templates in Markdown files
+
 ## [0.0.7] - 2021-07-07
 
 - Reregister the .tera extension

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tera",
   "displayName": "Tera",
   "description": "A powerful, easy-to-use template language based on Rust, inspired by Jinja2 and Django Templates.",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "publisher": "karunamurti",
   "engines": {
     "vscode": "^1.40.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tera",
   "displayName": "Tera",
   "description": "A powerful, easy-to-use template language based on Rust, inspired by Jinja2 and Django Templates.",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "publisher": "karunamurti",
   "engines": {
     "vscode": "^1.40.0"
@@ -31,6 +31,16 @@
           ".tera"
         ],
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "markdown",
+        "aliases": [
+          "Markdown"
+        ],
+        "extensions": [
+          ".md"
+        ],
+        "configuration": "./language-configuration.json"
       }
     ],
     "grammars": [
@@ -38,11 +48,20 @@
         "language": "html",
         "scopeName": "source.tera",
         "path": "./syntaxes/tera.json"
+      },
+      {
+        "language": "markdown",
+        "scopeName": "source.tera",
+        "path": "./syntaxes/tera.json"
       }
     ],
     "snippets": [
       {
         "language": "html",
+        "path": "./snippets/tera.code-snippets.json"
+      },
+      {
+        "language": "markdown",
         "path": "./snippets/tera.code-snippets.json"
       }
     ]


### PR DESCRIPTION
Hi,

I added support for snippets in markdown files to address issue #12. Extension is also updated to version 0.0.8.

New updates are included in the changelog.md file as well.